### PR TITLE
Introduce relative asset paths

### DIFF
--- a/src/content/docs/concepts/checkpoints.md
+++ b/src/content/docs/concepts/checkpoints.md
@@ -13,11 +13,11 @@ Blackbird has released a powerful new feature called Checkpoints, designed to en
 
 Checkpoints in Blackbird workflows are _control steps_ that enable Birds to **pause and wait** for different events before continuing their Flights. These triggers could be a mix of automated and human-driven actions. Instead of following a single, linear trigger path, Checkpoints allow for flexible handling of workflows where pauses for approvals, reviews, or external events are necessary.
 
-![Shopify to Phrase](../../../assets/guides/checkpoints/ShopifyToPhrase.png)
+![Shopify to Phrase](~/assets/guides/checkpoints/ShopifyToPhrase.png)
 
 Traditional workflows typically follow a single chain of events, triggered by one initial action (e.g., a file being uploaded or a task being assigned). With Checkpoints, multiple trigger points are embedded within a Bird, allowing for pauses and checks along the way. This creates more adaptable processes, especially useful when certain steps require human involvement or need to wait for external systems to respond or long running tasks to be completed. E.g. after sending a document for translation we have to wait for the translation to be done before we can publish it. **This feature turns complex multi-Bird workflows into one comprehensive Bird**.
 
-![MarketoToPlunet](../../../assets/guides/checkpoints/MarketoToPlunet.png)
+![MarketoToPlunet](~/assets/guides/checkpoints/MarketoToPlunet.png)
 
 ## What Advantages Do Checkpoints Offer?
 
@@ -31,27 +31,27 @@ Traditional workflows typically follow a single chain of events, triggered by on
 
 Click on the plus sign as you would to add any other step and select `Checkpoint`. Choose between waiting for an `Event` in an app to happen or a specific amount of time (`Delay`). If you've chosen to wait for an event, you need to click continue or go to the `Connection` tab, then select the app, the type of event, your connection and the ID for the exact object to monitor — if you are awaiting a project to be completed, you can specify the project ID so your Flight only continues once this specific project is completed. If the Delay option was selected instead, you need to specify the amount of time to wait in the `Duration` tab.
 
-![Adding a checkpoint GIF](../../../assets/guides/checkpoints/AddingCheckpoint.gif)
+![Adding a checkpoint GIF](~/assets/guides/checkpoints/AddingCheckpoint.gif)
 
 ## Examples
 
 ### Translation Management Systems (TMS)
 For businesses utilizing TMS tools (like Phrase or RWS WorldServer, etc.), translation tasks usually need to be performed by a human. Checkpoints allow workflows to halt until translations are reviewed or completed.
 
-![MemoQ wordpress with checkpoints](../../../assets/guides/checkpoints/wordpress_memoq.png)
+![MemoQ wordpress with checkpoints](~/assets/guides/checkpoints/wordpress_memoq.png)
 
 The image above shows a Bird that takes new posts from Wordpress, creates a project in memoQ, imports the posts as HTML source documents into the newly created memoQ project, waits for the project status in memoQ to be "Wrapped up", then downloads the translated documents and uploads them into Wordpress.
 
 ### Human Approvals in Project Management
 In platforms like Asana, Jira, or Trello, certain tasks require approval before proceeding. With Checkpoints, workflows can pause until the necessary review or approval is completed. This ensures nothing is missed, and approvals are smoothly integrated into the process.
 
-![Jira](../../../assets/guides/checkpoints/Jira.png)
+![Jira](~/assets/guides/checkpoints/Jira.png)
 
 The picture above shows a Bird with two Checkpoints. The flow starts whenever a new Zendesk article is published, the content from the new article is extracted as HTML and added as source file in a newly created Trados project. At this point, the process is paused and once the project is updated and reached the desired status, the target file is downloaded and added as attachment to a new Jira issue. A new halt is reached as the flow awaits for the status of the Jira issue to be changed, allowing for human intervention — maybe a legal or marketing team needs to review the translation. A decision point is reached afterwards: if the new status is "Approved", then the translated Zendesk article is published. Otherwise, the corresponding Teams channel is notified. 
 
 ### Large Language Models (LLMs) & Batch Processing
 When using LLM services like [OpenAI’s Batch API](https://docs.blackbird.io/apps/openai/#batch-processing) for content generation or data processing (especially long running tasks), a Checkpoint can pause the workflow until the LLM returns a result or a batch process completes. If further human validation is required, the workflow can wait for that input before moving to the next stage.
 
-![Open AI batch](../../../assets/guides/checkpoints/OpenAICheckpoint.png)
+![Open AI batch](~/assets/guides/checkpoints/OpenAICheckpoint.png)
 
 The image above depicts a Bird where bilingual files are exported from Phrase as soon as jobs reach a specific status, then said files are process via OpenAI Batch API. The workflow comes to a halt until the Batch processing is completed and once this happens, the resulting files are uploaded back to Phrase. 

--- a/src/content/docs/concepts/flights.md
+++ b/src/content/docs/concepts/flights.md
@@ -14,4 +14,4 @@ To check your flights, navigate to the _Flights_ tab and click on a flight in th
 
 You can click _Edit_ to open the editor page of the current Bird, where you can make the necessary edits.
 
-![connection](../../../assets/docs/flight-details.png)
+![connection](~/assets/docs/flight-details.png)

--- a/src/content/docs/concepts/libraries.md
+++ b/src/content/docs/concepts/libraries.md
@@ -22,15 +22,15 @@ Libraries are used to:
 
 In Blackbird, there is a dedicated tab for Libraries (navigation bar at the top right). The default use case is for language codes: even though there are standards, each app uses a different one to refer to the same language. Therefore, we use the default library to store different code variants referring to the same locale across apps.
 
-![Library Tab and Default Library](../../../assets/docs/libraries/LibrariesTab.gif)
+![Library Tab and Default Library](~/assets/docs/libraries/LibrariesTab.gif)
 
 Within your workflow (Bird), you can reference the library by using the Convert operator. Click on the plus sign, as if you were adding an action, but select Operator instead. Then choose `Convert`, the library to use, and the pieces of data you want to go from and to. Once your Bird is flying (_workflow running_), data gets transformed and routed accordingly.
 
-<!-- ![Convert Operator](../../../assets/docs/libraries/Convert.gif) -->
+<!-- ![Convert Operator](~/assets/docs/libraries/Convert.gif) -->
 
 Here is one example where the output of one tool becomes the input of the next one, and in between, the Convert operator follows the rules in the library to ensure everything works smoothly in terms of interoperability, even when the two tools use different standards to refer to languages. In this case, we get the list of locales missing a translation for a particular article in Zendesk and we want to translate the articles into these languages through DeepL. However, we know DeepL uses a different code to refer to the same languages. Hence, we set up these codes once in our library, add the Convert operator as part of our workflow, and we have a fully functional Bird now that won't be interrupted because two apps _don't speak the same language_.
 
-![Example Bird](../../../assets/docs/libraries/SampleBird.png)
+![Example Bird](~/assets/docs/libraries/SampleBird.png)
 
 While the default Library is read-only, you can create your own custom libraries.
 
@@ -44,7 +44,7 @@ While you can benefit from using the Languages library, you can also create one 
 | 2 | Technical      | Template B       | 0.85              |
 | 3 | User generated | Template C       | 0.8               |
 
-![Custom](../../../assets/docs/libraries/Custom.png)
+![Custom](~/assets/docs/libraries/Custom.png)
 
 ## How to Create Your Own Library
 
@@ -52,14 +52,14 @@ To add a new library you can:
 
 1. Click the `Add Library` button. Choose a name and description. Open the library and manually add rows and columns, populating the content by filling in the cells with relevant values.
 
-![Add Library](../../../assets/docs/libraries/AddLibrary.gif)
+![Add Library](~/assets/docs/libraries/AddLibrary.gif)
 
 2. Clone an existing library and edit its content.
 
-![Clone Library](../../../assets/docs/libraries/CloneLibrary.gif)
+![Clone Library](~/assets/docs/libraries/CloneLibrary.gif)
 
 3. Import one or multiple .csv files using the `Import` button. The file's content will become the library's, using the top row as column headers and left column as entity names. By default, your first file's name will become the library's name unless you edit it. Name and description can also be edited later on.
 
-![Import Library](../../../assets/docs/libraries/ImportLibrary.gif)
+![Import Library](~/assets/docs/libraries/ImportLibrary.gif)
 
 > Libraries can also be copied into other Nests, exported as `.csv` files, renamed, and deleted.

--- a/src/content/docs/concepts/nests.md
+++ b/src/content/docs/concepts/nests.md
@@ -15,17 +15,17 @@ In this guide you will learn about Blackbird's way to compartmentalizing your pr
 
 Keeping your data separated not only fortifies security measures but also enhances productivity as a clear delineation of data compartment eliminates unnecessary clutter. Consider creating a separate Nest for each of your clients or per stage of your workflow design process (playground, QA, production) - or even both as Nests can also have subnests for further organization. On the top right, click on your profile picture and select Organization Management. The first option on the left is Nests, you will see a list of the existing Nests under your organization along with their names, total users and creation date. By clicking on a specific Nest, you will see more details, such as each user that has been added, and you also have the option to delete said Nest.
 
-![Nests details of users](../../../assets/guides/nests/1.png)
+![Nests details of users](~/assets/guides/nests/1.png)
 
 At the top, you'll find a 'Create Nest' button to establish a new compartment.
 
-![Nests create button](../../../assets/guides/nests/2.png)
+![Nests create button](~/assets/guides/nests/2.png)
 
 If you want to add a subnest under an existing one, simply click the plus sign at the end of the Nest's row.
 
-![Create subnest](../../../assets/guides/nests/31.png)
+![Create subnest](~/assets/guides/nests/31.png)
 
-![Create subnest](../../../assets/guides/nests/32.png)
+![Create subnest](~/assets/guides/nests/32.png)
 
 Subnests inherit apps' credentials from their parent Nest. You may want to have one Nest for Client 1, add their credentials for the required apps to this Nest, and then create subnests for the different work stages. The users with access to the subnests will be able to connect to these apps, make them part of their workflows while choosing the credentials you have added to the parent Nest, however they won't be able to manage (or see the details of) said credentials. This means you only need to enter information once, as it is automatically inherited by subnests.
 
@@ -33,13 +33,13 @@ Subnests inherit apps' credentials from their parent Nest. You may want to have 
 
 You can also define who has access to each of these instances and what they can see or do, keeping a very granular access control. On the Users tab, you can see all the people that have been invited to your organization, their role and status. On the top right, you can choose to _Add User_. You will need to fill in their name, email address and choose the appropriate role(s) and Nest(s) they will be able to access. Once you add a user, they will receive an e-mail invite prompting them to generate a password to access Blackbird.
 
-![Add User](../../../assets/guides/nests/4.png)
+![Add User](~/assets/guides/nests/4.png)
 
 ## Roles
 
 By default, you will see User and Admin roles as available options. However, this can be tailored to align with specific responsibilities and access requirements. Roles can be edited (by clicking on the specific role you want to update), deleted or created from scratch. To create a new role, simply click on _Add role_, provide a name for this role and choose which permissions you want to grant.
 
-![Available permissions](../../../assets/guides/nests/5.png)
+![Available permissions](~/assets/guides/nests/5.png)
 
 As an example, you may want to invite one of your clients to your Blackbird instance and give them a "Client" role that only entitles them to add their credentials to connect to an app. This way you avoid data manipulation or sharing. You may have clients that need a more _empowered_ role because they want to review processes, for this purpose, you can give them a broader but read only access. Or you may want to have a more collaborative approach and enable them to build workflows with you. All of this is possible and, just like everything else at Blackbird, you define it.
 
@@ -47,4 +47,4 @@ As an example, you may want to invite one of your clients to your Blackbird inst
 
 Finally, there is a whitelabelling option under the _Branding_ tab that allows you to upload your own logo (to replace Blackbird's on the top left corner) and customize your instance's look.
 
-![Branding](../../../assets/guides/nests/6.png)
+![Branding](~/assets/guides/nests/6.png)

--- a/src/content/docs/concepts/triggers.md
+++ b/src/content/docs/concepts/triggers.md
@@ -12,7 +12,7 @@ All processes must begin at some point: a **trigger** is what defines when a wor
 
 Manual triggers (also referred to as [Manual push](https://docs.blackbird.io/guides/manual-triggers/)) are activated by human intervention. These workflows start as soon as someone clicks the `Fly` button. This type of trigger is ideal for testing and debugging, or when processes need to be started based on specific, often unpredictable, conditions that require human judgment. This is the recommended trigger type while you are in the process of building your Birds.
 
-![Fly button](../../../assets/docs/triggers/Fly.gif)
+![Fly button](~/assets/docs/triggers/Fly.gif)
 
 **Key Features**:
 
@@ -26,7 +26,7 @@ Scheduled triggers are time-based and initiate processes at predefined intervals
 
 In Blackbird, you can choose an interval—from the moment the Bird is published, every X amount of hours or minutes the Bird will be triggered. Another option is to start the process daily at a specific time, or always on a set day of the week/month. Additionally, you can specify a timezone to avoid any confusion.
 
-![Scheduled](../../../assets/docs/triggers/Scheduled.gif)
+![Scheduled](~/assets/docs/triggers/Scheduled.gif)
 
 **Key Features**:
 
@@ -42,7 +42,7 @@ Once you select the Event type, move to the Connection tab or click Continue, ch
 
 In the image below, we can choose to react to a number of different events happening in Zendesk, for instance, a new article being published. 
 
-![Event](../../../assets/docs/triggers/Event.png)
+![Event](~/assets/docs/triggers/Event.png)
 
 In case any extra setting is needed (some apps require this), you may see an URL that needs to be copy-pasted somewhere. In such scenarios, details will be specified in the app's section within Blackbird documentation. 
 
@@ -58,13 +58,13 @@ Sometimes, reacting every single time something happens can create clutter as th
 
 In the image below, following the previous example, we don't want to create a new TMS project each time an article is published in Zendesk. Instead, we wait until at least five articles are published or two hours have passed, whichever happens first. If after two hours only three articles were published, the Bird will execute anyway and create a new TMS project for those three articles. This adjustment ensures that processes are responsive enough without creating excessive noise.
 
-![Bucketing](../../../assets/docs/triggers/Bucketing.png)
+![Bucketing](~/assets/docs/triggers/Bucketing.png)
 
 ## Polling
 
 Since some systems don't have webhooks or callbacks, but we would still like to be diligent and reactive, Blackbird has launched Polling events. For the regular user, this trigger looks exactly like an event-based one, while, under the hood, Blackbird is checking for changes at specified intervals. This type of scheduled trigger looks for updates in an app's data to decide whether to start a workflow, bridging the gap for apps that don't provide webhooks by allowing our Birds to react in _real time_.
 
-![Polling](../../../assets/docs/triggers/Polling.gif)
+![Polling](~/assets/docs/triggers/Polling.gif)
 
 ## Checkpoints
 

--- a/src/content/docs/eggs/blackbird-app.md
+++ b/src/content/docs/eggs/blackbird-app.md
@@ -25,7 +25,7 @@ The most popular use case for the Blackbird app in Blackbird is monitoring faile
 
 > Use optional inputs to monitor a specific Nest, otherwise a single Bird will monitor all Nests within your Blackbird instance.
 
-![Egg](../../../assets/docs/eggs/BBApp1.png)
+![Egg](~/assets/docs/eggs/BBApp1.png)
 Error escalation Bird
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Report_failed_Flights_on_Slack.json" download>Report failed Flights on Slack</a>
@@ -33,7 +33,7 @@ Error escalation Bird
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Report_failed_Flights_via_Outlook_email.json" download>Report failed Flights via Outlook email</a>
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Report_failed_Flights_via_Gmail.json" download>Report failed Flights via Gmail</a>
 
-![Egg](../../../assets/docs/eggs/BBApp2.png)
+![Egg](~/assets/docs/eggs/BBApp2.png)
 Error logging Bird
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Log_failed_Flights_on_Google_Sheets.json" download>Log failed Flights on Google Sheets</a>
@@ -43,7 +43,7 @@ Error logging Bird
 
 Monitor users added or removed from a specific Nest.
 
-![Egg](../../../assets/docs/eggs/BBApp3.png)
+![Egg](~/assets/docs/eggs/BBApp3.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/On_user_removed_send_Slack_message.json" download>On user removed send Slack message</a>
 
@@ -51,7 +51,7 @@ Monitor users added or removed from a specific Nest.
 
 Get notified when Birds are suspended or activated: get real-time notifications of changes in your Production Nest.
 
-![Egg](../../../assets/docs/eggs/BBApp4.png)
+![Egg](~/assets/docs/eggs/BBApp4.png)
 
 > Use optional inputs to monitor a specific Nest, otherwise, a single Bird will monitor all Nests within your Blackbird instance.
 
@@ -69,4 +69,4 @@ To import an Egg into your Nest:
 6. Click on the three dots next to the Bird's name and update the apps if there are updates available.
 7. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/eggs/emails.md
+++ b/src/content/docs/eggs/emails.md
@@ -34,16 +34,16 @@ New order/project details are sent as reply. Machine translated files can also b
 - **Polling Events:** Some apps use [polling](https://docs.blackbird.io/concepts/triggers/#polling) instead of webhooks to detect new emails. Check for an _Interval_ tab when setting up your trigger and choose the appropriate time for you (between 5 minutes and 7 days).
 
 Egg getting emails from Outlook into DeepL and Trados.
-![Egg with emails](../../../assets/docs/eggs/Egg6_Outlook_DeepL_Trados.png)
+![Egg with emails](~/assets/docs/eggs/Egg6_Outlook_DeepL_Trados.png)
 
 Closer look at reply email.
-![Email reply](../../../assets/docs/eggs/Egg6_InstantReply.png)
+![Email reply](~/assets/docs/eggs/Egg6_InstantReply.png)
 
 Example prompt to get language codes
-![LLM prompt](../../../assets/docs/eggs/Egg6_GetLanguageExample.png)
+![LLM prompt](~/assets/docs/eggs/Egg6_GetLanguageExample.png)
 
 Extracting language codes using Regular expressions.
-![Regex](../../../assets/docs/eggs/Egg6_ExtractLanguagesRegex.png)
+![Regex](~/assets/docs/eggs/Egg6_ExtractLanguagesRegex.png)
 
 ## Download an Egg
 
@@ -64,4 +64,4 @@ To import an Egg into your Nest:
 5. Update the Connection details and any other needed input/output parameters or desired steps. Look for red warning signs next to the step name signaling missing details in said step.
 6. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/eggs/remote.md
+++ b/src/content/docs/eggs/remote.md
@@ -21,7 +21,7 @@ In this Egg-guide, let's explore some options to integrate [Remote.com](https://
 
 The Bird shown below creates a new employment in Remote as soon as a new Resource has been set as Active in Plunet.
 
-![PlunettoRemote](../../../assets/docs/eggs/PlunetResourceActivatedCreateRemoteEmployment.png)
+![PlunettoRemote](~/assets/docs/eggs/PlunetResourceActivatedCreateRemoteEmployment.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Plunet_resource_activated_to_Remote_Employment.json" download>On Plunet resource activated create Remote employment</a>
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Remote_employment_completed_set_Plunet_resource_Active.json" download>On Remote employment completed set Plunet resource active</a>
@@ -30,7 +30,7 @@ The Bird shown below creates a new employment in Remote as soon as a new Resourc
 
 This Bird is triggered weekly, searches invoices in XTRF that been updated during the last week, exports them and imports them into Remote. Note the Convert operator being used to pull data from a custom library. 
 
-![XTRFtoRemote](../../../assets/docs/eggs/XtrfInvoiceToRemote.png)
+![XTRFtoRemote](~/assets/docs/eggs/XtrfInvoiceToRemote.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/XTRF_invoice_to_Remote.json" download>XTRF invoice to Remote</a>
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Remote_to_XTRF_invoice_status_update.json" download>Remote to XTRF invoice status update</a>
@@ -39,7 +39,7 @@ This Bird is triggered weekly, searches invoices in XTRF that been updated durin
 
 The image below displays a Bird that is triggered whenever a time off request has been approved in Remote, then adds an event to Microsoft 365 calendar, logs the time-off details in an Excel sheet and sends a Slack notification.
 
-![RemoteTimeoffApproved](../../../assets/docs/eggs/RemoteTimeoffApproved.png)
+![RemoteTimeoffApproved](~/assets/docs/eggs/RemoteTimeoffApproved.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/On_timeoff_approved_add_to_Calendar_Excel.json" download>On timeoff approved add to calendar and Excel</a>
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Manual_payout_notification.json" download>Monthly manual payout notification</a>
@@ -63,4 +63,4 @@ To import an Egg into your Nest:
 5. Update the Connection details and any other needed input/output parameters or desired steps. Look for red warning signs next to the step name signaling missing details in said step.
 6. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/eggs/spreadsheets.md
+++ b/src/content/docs/eggs/spreadsheets.md
@@ -21,7 +21,7 @@ Spreadsheets can be a powerful tool to capture key data points at various stages
 
 The `Add new sheet row` action in Blackbird is ideal for this purpose. It **appends a new row at the end of the spreadsheet's used range** and allows multiple data points to be passed into consecutive cells, maintaining the order you specify in Blackbird. It will also check if there are rows available (Google Sheets) and add one in case we are at the spreadsheet's end. 
 
-![Add new sheet row](../../../assets/docs/eggs/AddNewSheetRow.png)
+![Add new sheet row](~/assets/docs/eggs/AddNewSheetRow.png)
 
 ### Searching and Updating Information
 
@@ -29,11 +29,11 @@ Managing dynamic data in spreadsheets often involves searching for and updating 
 Example: You may have a column in your table with unique order IDs. Every time an update occurs, you want to log these changes (maybe a status update) in your spreadsheet, use the `Find sheet row` action to locate the relevant row for that particular order, and subsequent actions like `Update sheet row` or `Update sheet cell` will allow you to modify information —such as the order status— in a different column but corresponding row.
 This action can also be paired with a decision point to check if the unique value already exists in the spreadsheet. If the output is null, you can add a new entry; otherwise, update the existing one.
 
-![FindSheetRow](../../../assets/docs/eggs/FindSheetRow.png)
+![FindSheetRow](~/assets/docs/eggs/FindSheetRow.png)
 
 The same can be done in Airtable. The image below shows a Bird tha starts whenever a project status has been updated in Bureau Works, then the ID of the updated project is used as unique identifier in a column and we get the row information back by using the `Search record` action. Then, we update the correct cell with the new status for the corresponding project. Keeping my project information up to date. 
 
-![AirtableSearchRecord](../../../assets/docs/eggs/AirtableSearchRecord.png)
+![AirtableSearchRecord](~/assets/docs/eggs/AirtableSearchRecord.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/Bureau_Works_to_Airtable.json" download>Airtable Search record</a>
 
@@ -48,7 +48,7 @@ If you already know the rows or subset of rows you want to work with, you can ge
 3. Inside the loop, use the `Get sheet cell` action to retrieve data by composing the cell address (combining the known column with the current row number from the loop).
 4. After processing the extracted data, use the `Update sheet cell` action to add your result, or mark the row as processed.
 
-![Generate range](../../../assets/docs/eggs/GenerateRange.png)
+![Generate range](~/assets/docs/eggs/GenerateRange.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/excel_generate_range.json" download>Microsoft Excel Generate Range</a>
 
@@ -60,7 +60,7 @@ In a very similar fashion, when the number of rows in the spreadsheet is unknown
 
 > Note that you can input 2 as the start row for your range generation in case you want to spare the spreadsheet headers.
 
-![Generate range Google Sheets](../../../assets/docs/eggs/GenerateRange2.png)
+![Generate range Google Sheets](~/assets/docs/eggs/GenerateRange2.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/google_sheets_generate_range.json" download>Google Sheets Generate Range</a>
 
@@ -72,11 +72,11 @@ If you need to extract multiple values from each row, treating each row as an ar
 3. Use the `Get entry by position` action from the Utilities app to extract specific column values based on their position in the array (e.g., position 3 for column C).
 4. After you have processed the data, you can `Update sheet cell` by composing the cell address (using Row ID from the loop and specifying the column)
 
-![Iterate through range](../../../assets/docs/eggs/IterateThroughRangeSheets.png)
+![Iterate through range](~/assets/docs/eggs/IterateThroughRangeSheets.png)
 
 Another variant, using a subset and multiple column entries as input for other actions:
 
-![Iterate through range](../../../assets/docs/eggs/IterateThroughRangeExcel.png)
+![Iterate through range](~/assets/docs/eggs/IterateThroughRangeExcel.png)
 
 - Download Egg: <a href="https://docs.blackbird.io/downloads/google_sheets_iterate_through_range.json" download>Google Sheets Iterate through Range</a>
 - Download Egg: <a href="https://docs.blackbird.io/downloads/microsoft_excel_iterate_through_range.json.json" download>Microsoft Excel Generate Range</a>
@@ -87,13 +87,13 @@ In some workflows, it might be necessary to handle bulk updates or retrieve mult
 #### Update Sheet Column
 When you have a list or array of values (e.g., target language codes or file names) that you want to populate in a spreadsheet column, the `Update sheet column` action makes it easy. This action can take as input one or more arrays and/or a group of single values. These will be written into the spreadsheet's specified column one value below the other starting in the provided cell address and respecting the same order as they were listed in the action's input.
 
-![Update Sheet Column](../../../assets/docs/eggs/Update-sheet-column.png)
+![Update Sheet Column](~/assets/docs/eggs/Update-sheet-column.png)
 
 #### Get Sheet Column
 
 Similarly, you might need to retrieve a set of values from a specific column for later use. Use the `Get column` action to specify the column (e.g., column C) and the start and end cells (e.g., 1 to 10). The output will be an array containing the values from the specified column range that you can later use as input for the subsequent steps.
 
-![Get column](../../../assets/docs/eggs/GetColumn.png)
+![Get column](~/assets/docs/eggs/GetColumn.png)
 
 ## Importing Eggs
 
@@ -106,4 +106,4 @@ To import an Egg into your Nest:
 5. Update the Connection details and any other needed input/output parameters or desired steps. Look for red warning signs next to the step name signaling missing details in said step.
 6. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/eggs/storage-to-mt.md
+++ b/src/content/docs/eggs/storage-to-mt.md
@@ -25,7 +25,7 @@ The downloaded files are sent to a machine translation engine for quick processi
 Translated files are uploaded back to the cloud storage, placed in a designated output folder.
 
 Egg between Google Drive and DeepL
-![Egg](../../../assets/docs/eggs/Eggs1.png)
+![Egg](~/assets/docs/eggs/Eggs1.png)
 
 ## Tips
 
@@ -39,10 +39,10 @@ Egg between Google Drive and DeepL
 - **File renaming:** You can change the name of files before re-uploading them. If you want to append the target language code at the end of your file name or indicate through the file name that it has been MTed, you can use the [Utilities](https://docs.blackbird.io/apps/utilities/) app or other [helpers](https://docs.blackbird.io/guides/toolbox/). There is a downloadable workflow example for this at the [bottom of the page](https://docs.blackbird.io/eggs/storage-to-mt/#download-an-egg).
 
 Egg between Google Drive and DeepL with glossaries.
-![Egg with Glossary](../../../assets/docs/eggs/Eggs1_withGlossary.png)
+![Egg with Glossary](~/assets/docs/eggs/Eggs1_withGlossary.png)
 
 Adding an array of language codes to a loop.
-![Multiple languages](../../../assets/docs/eggs/MultipleLangs.png)
+![Multiple languages](~/assets/docs/eggs/MultipleLangs.png)
 
 ## Suggested Apps
 
@@ -64,10 +64,10 @@ Adding an array of language codes to a loop.
 - [Google Translate](https://docs.blackbird.io/apps/google-translate/)
 
 Egg between Dropbox and GlobalLink NOW
-![Egg GL NOW](../../../assets/docs/eggs/Eggs1_GlobalLinkNow.png)
+![Egg GL NOW](~/assets/docs/eggs/Eggs1_GlobalLinkNow.png)
 
 Egg between Amazon S3 and Lanugage Weaver
-![Egg S3 Language Weaver](../../../assets/docs/eggs/Eggs1_S3toLanguageWeaver.png)
+![Egg S3 Language Weaver](~/assets/docs/eggs/Eggs1_S3toLanguageWeaver.png)
 
 ## Download an Egg
 
@@ -92,4 +92,4 @@ To import an Egg into your Nest:
 5. Update the Connction details and any other needed input/output parameters or desired steps. Look for red warning signs next to the step name signaling missing details in said step.
 6. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/eggs/tms-to-llm.md
+++ b/src/content/docs/eggs/tms-to-llm.md
@@ -25,7 +25,7 @@ The downloaded files are sent to an LLM for processing.
 Processed files are uploaded back to the TMS.
 
 Egg between Phrase and Anthropic
-![Egg](../../../assets/docs/eggs/Egg2-Phrase-to-Anthropic.png)
+![Egg](~/assets/docs/eggs/Egg2-Phrase-to-Anthropic.png)
 
 ## Tips
 
@@ -38,10 +38,10 @@ Egg between Phrase and Anthropic
 - **Loops are needed:** Whether to iterate through a list of target languages or to send each file within a group of downloaded files to an action that only takes one at a time, [loops](https://docs.blackbird.io/guides/loops/) are the key.
 
 Egg between MemoQ and Anthropic
-![Egg simple](../../../assets/docs/eggs/Egg2-memoQ-to-Anthropic.png)
+![Egg simple](~/assets/docs/eggs/Egg2-memoQ-to-Anthropic.png)
 
 Egg between MemoQ and OpenAI with glossaries.
-![Egg with Glossary](../../../assets/docs/eggs/Egg2-memoQ-to-OpenAI-with-glossary.png)
+![Egg with Glossary](~/assets/docs/eggs/Egg2-memoQ-to-OpenAI-with-glossary.png)
 
 ## Suggested Apps
 
@@ -72,4 +72,4 @@ To import an Egg into your Nest:
 6. Click on the three dots next to the Bird's name and update the apps if there are updates available.
 7. Click Save/Publish.
 
-![Importing Eggs](../../../assets/docs/eggs/ImportEggs.gif)
+![Importing Eggs](~/assets/docs/eggs/ImportEggs.gif)

--- a/src/content/docs/guides/beginner-bird.md
+++ b/src/content/docs/guides/beginner-bird.md
@@ -16,7 +16,7 @@ By the end of this guide, you will have built a Slack bot that responds to your 
 
 Nagivate to the birds page and click on the big purple button **Create**. This opens the bird editor. You will be greeted by the following screen.
 
-![Empty bird](../../../assets/guides/beginner-bird/empty.png)
+![Empty bird](~/assets/guides/beginner-bird/empty.png)
 
 Let's go over the elements on the screen:
 
@@ -26,29 +26,29 @@ Let's go over the elements on the screen:
 
 To build the simplest bird possible we are going to select **Manual trigger** on the right side of the screen. A manual trigger means that we can trigger this bird from inside Blackbird by clicking a button.
 
-![Manual trigger](../../../assets/guides/beginner-bird/manual_trigger.png)
+![Manual trigger](~/assets/guides/beginner-bird/manual_trigger.png)
 
 Now it's time to define our first action. We do this by clicking on the **+** icon in the center of the screen and selecting **Action**.
 
-![Action](../../../assets/guides/beginner-bird/action.png)
+![Action](~/assets/guides/beginner-bird/action.png)
 
 You will see a new action underneath your trigger. However, the action is still empty and we must define what to do with which app and which connection.
 Go ahead and click on app on the right side of your screen. Search for the app that you want to add the action for. In our case this is _Slack_.
 
-![Action added](../../../assets/guides/beginner-bird/action_added.png)
+![Action added](~/assets/guides/beginner-bird/action_added.png)
 
 After defining the app, we now have to define the action we want to take. We are going to send a message in Slack so search for _Send message_ and select it.
 Finally, we select the connection. You can click on **Add new connection** if you haven't created a Slack connection yet.
 
 The final result should look like this:
 
-![Action added](../../../assets/guides/beginner-bird/action_configured.png)
+![Action added](~/assets/guides/beginner-bird/action_configured.png)
 
 Now that we knows what to do, we have to tell Blackbird what information to send. Click on the purple button **Continue**, or on the tab that says **Inputs**.
 
 Your actions require extra information in order to execute. Some of this information is required, some of it is optional. We can see in the image below that the _Channel ID_ is a required parameter for the action: Blackbird wants to know to which channel the message should be sent.
 
-![Send message](../../../assets/guides/beginner-bird/send_message.png)
+![Send message](~/assets/guides/beginner-bird/send_message.png)
 
 When passing information to an action we need to be aware that this information can come from either of two places:
 
@@ -59,7 +59,7 @@ When passing information to an action we need to be aware that this information 
 
 Let's define the _Channel ID_ that Blackbird wants from us. The channels that are possible values for this parameter are finite and pre-defined. Therefore, when you click on **Select input data** Blackbird will actually show you the channels that are available to you from the connection!
 
-![Channels](../../../assets/guides/beginner-bird/channels.png)
+![Channels](~/assets/guides/beginner-bird/channels.png)
 
 You can type in the search box in order to narrow down your search. Select a channel that you want to use for this bird, in our case we are going to simply select the _#general_ channel.
 
@@ -69,15 +69,15 @@ We have defined what channel to send the message to, great! Now we also have to 
 
 Your action should now look something like this:
 
-![Send message complete](../../../assets/guides/beginner-bird/send_message_complete.png)
+![Send message complete](~/assets/guides/beginner-bird/send_message_complete.png)
 
 That's it! Now it's time to fly your first bird. You do this by clicking on the purple **Fly** button on the top of the screen.
 
-![Fly](../../../assets/guides/beginner-bird/fly.png)
+![Fly](~/assets/guides/beginner-bird/fly.png)
 
 You should almost instantly see the message in your Slack channel!
 
-![From Slack](../../../assets/guides/beginner-bird/from_slack.png)
+![From Slack](~/assets/guides/beginner-bird/from_slack.png)
 
 It is now possible to also verify the execution of this bird in BLackbird. We do this by clicking on **Show Flights** next to the fly button. You will see a list of flights. When clicking on a flight you can inspect every event and action that has executed. By clicking on an action you can also see the input and output values that were passed through.
 
@@ -85,15 +85,15 @@ It is now possible to also verify the execution of this bird in BLackbird. We do
 
 Let's add a second step to the bird. We want to first translate a sentence using DeepL, and then send the translation to our Slack channel. In order to do this, we need to add a new action. This action should happen _before_ we send the message to Slack. That's why we are creating a new action in between the trigger and **Send message**. Click on the **+** icon and select action again.
 
-![Action in between](../../../assets/guides/beginner-bird/action_in_between.png)
+![Action in between](~/assets/guides/beginner-bird/action_in_between.png)
 
 This time we are not selecting Slack as our app but DeepL. Then select the action **Translate** and your connection (create one if you don't have any yet). Your screen should then look like this:
 
-![DeepL Added](../../../assets/guides/beginner-bird/deepl_added.png)
+![DeepL Added](~/assets/guides/beginner-bird/deepl_added.png)
 
 It's time to fill in the information again by clicking on **Continue**. This time two fields are required: _Text_ and _Target language_. We are free to type in any text we want, we also see that _Target language_ will present us with a dropdown. Fill in a text to translate and select a target language, in this case we are going for _Hello from Blackbird!_ and _Spanish_.
 
-![Translate filled](../../../assets/guides/beginner-bird/translate_filled.png)
+![Translate filled](~/assets/guides/beginner-bird/translate_filled.png)
 
 > **💡 Note**: When inspecting the optional values we see that DeepL can take in a lot more information, feel free to explore these options!
 
@@ -103,11 +103,11 @@ We do this by going back to our Send message action by clicking on it. You see t
 
 Click on the magic wand in front of the _Message_ field. The input field now changes to a dropdown. Click on the dropdown and you are presented with the information that is returned from DeepL.
 
-![Slack DeepL input](../../../assets/guides/beginner-bird/slack_deepl_input.png)
+![Slack DeepL input](~/assets/guides/beginner-bird/slack_deepl_input.png)
 
 You may notice that Blackbird is also warning you that your workflow is incomplete. Let's quickly click on **Translated text** as that is the information we want to send from DeepL to Slack. After you have done this, everything should look fine and it is time to click on the **Fly** button again!
 
-![Result Spanish](../../../assets/guides/beginner-bird/result_spanish.png)
+![Result Spanish](~/assets/guides/beginner-bird/result_spanish.png)
 
 🥳 ¡Felicidades! You have just created a bird that demonstrates the most important aspect of Blackbird: taking information from one application and passing it onto another one. Feel free to click on _Show Flights_ again to see all the information about the flight. After having done that, are you ready to take it to the next level?
 
@@ -118,21 +118,21 @@ It's time to change this manual trigger. What we want to achieve is that if some
 
 Let's start by clicking on the **Manual trigger**. On the right side we can now change it to an **Event trigger**. Event trigger always means that we are triggering based on things happening in connected applications.
 
-![Event trigger](../../../assets/guides/beginner-bird/event_trigger.png)
+![Event trigger](~/assets/guides/beginner-bird/event_trigger.png)
 
 Unlike the manual trigger, the event trigger does require some configuration. After you click on **Continue** you'll be presented with a familiar menu. It's time to select the app, event and connection. For app select Slack and for the event select **On app mentioned**
 
-![Trigger config](../../../assets/guides/beginner-bird/trigger_config.png)
+![Trigger config](~/assets/guides/beginner-bird/trigger_config.png)
 
 > **⚠️ Warning**: you may be inclined to use the **on message** event. This would be a mistake though, as during this bird we are also going to send a message back to Slack, which would in turn trigger the bird again. That's an infinite loop! You will find that being aware of scenarios like this is going to be the actual difficult part of _Solution architecting_.
 
 If we would publish the bird like this, Blackbird would respond to any message with it being tagged _in any channel_. If you only want Blackbird to listen to a specific channel, then click on **Inputs** and select a channel for **Channel ID**.
 
-![Slack event input](../../../assets/guides/beginner-bird/slack_event_input.png)
+![Slack event input](~/assets/guides/beginner-bird/slack_event_input.png)
 
 Now that we have changed the trigger to an event, we don't see the **Fly** button anymore. Instead we see **Save** and after clicking on **Save** we see **Publish**.
 
-![Publish](../../../assets/guides/beginner-bird/publish.png)
+![Publish](~/assets/guides/beginner-bird/publish.png)
 
 Go ahead and click on **Publish**. Behind the scenes Blackbird is now contacting Slack and telling it to notify it whenever a user is sending a message that mentions it is sent.
 
@@ -140,13 +140,13 @@ Let's see it in action! Go to your channel and send a message tagging _@Blackbir
 
 > **💡 Note** you may have read in the Slack documentation that for in order for events to work, the Slack app needs to be added to a channel. You can do this through the Slack channel menu, or by sending a message with _@Blackbird_, Slack will then prompt you if you want to add the app to that channel. Agree.
 
-![Oops](../../../assets/guides/beginner-bird/message_oops.png)
+![Oops](~/assets/guides/beginner-bird/message_oops.png)
 
 Oops! You see that we have changed the bird to trigger whenever we are sending a message that includes _@Blackbird_. However, it is not doing what we want yet. We want to translate our message, not get the same translation of our static text of course!
 
 Let's quickly fix this by going into the **Translate** action. It's time to use that magic wand again! Instead of the keyboard input for **Text** we are going to want to select our message that came in to our event. Click on the magic wand and then select **Message** from the dropdown.
 
-![Dynamic message](../../../assets/guides/beginner-bird/dynamic_message.png)
+![Dynamic message](~/assets/guides/beginner-bird/dynamic_message.png)
 
 Remember: we are passing information (our message) from the event to DeepL. Then we are passing the information (our translated message) from DeepL to Slack again.
 
@@ -154,7 +154,7 @@ Remember: we are passing information (our message) from the event to DeepL. Then
 
 Click **Save** and **Publish**. It's time to try again and see if our bird works now!
 
-![Slack correct](../../../assets/guides/beginner-bird/slack_correct.png)
+![Slack correct](~/assets/guides/beginner-bird/slack_correct.png)
 
 🎉 ¡Súper genial! you just created a bird that responds to your messages on Slack and translates them into Spanish! Now this is already a pleasure to play with, but can we turn the fun up to 11 by introducing OpenAI?
 
@@ -164,11 +164,11 @@ It's time to add our last app: OpenAI. Instead of translating our message into S
 
 For your action, select **OpenAI** and **Chat**. Click **Continue** and select the message we want to send to OpenAI. Of course, this is the message we just received from Slack.
 
-![Open AI chat](../../../assets/guides/beginner-bird/openai_chat.png)
+![Open AI chat](~/assets/guides/beginner-bird/openai_chat.png)
 
 Let's also not repeat the same mistake we made during step 3: we now also need to update the next action to take the right information. Click on **Translate** and then on the parameter for **Text**. Instead of the message that came in from the event we now select the message that we get back from OpenAI.
 
-![Open AI message](../../../assets/guides/beginner-bird/openai_message.png)
+![Open AI message](~/assets/guides/beginner-bird/openai_message.png)
 
 You may realize by now, that configuring Blackbird birds is really an exercise of _connect the dots_.
 
@@ -176,7 +176,7 @@ That's it! It's time to **Save** and **Publish** again.
 
 It's time for the moment we have all been waiting for. Let's ask Blackbird a question on Slack and see what happens.
 
-![Bot complete](../../../assets/guides/beginner-bird/slack_bot_complete.png)
+![Bot complete](~/assets/guides/beginner-bird/slack_bot_complete.png)
 
 🙌 ¡increíble! We just created a Spanish slack bot in just a few steps. Congratulations! If you are curious what the English message was, then click on **Show Flights**, select the most recent flight and click on **Chat** under **Outputs** you can see exactly what OpenAI returned.
 
@@ -190,6 +190,6 @@ Before following any of the more advanced tutorials we encourage you to play aro
 
 Our final bonus tip is to use the clone functionality in the top menu. By cloning a bird you can very quickly make some changes and test them while maintaining your original bird.
 
-![Cloning](../../../assets/guides/beginner-bird/cloning.png)
+![Cloning](~/assets/guides/beginner-bird/cloning.png)
 
 Good luck and have fun!

--- a/src/content/docs/guides/cms-contentful.md
+++ b/src/content/docs/guides/cms-contentful.md
@@ -51,7 +51,7 @@ At their core, all workflows involving CMSs will contain the following structure
 
 The 3 P's of CMS workflows will always find their way into your birds.
 
-![Schematic](../../../assets/guides/cms/1729004201270.png)
+![Schematic](~/assets/guides/cms/1729004201270.png)
 
 It is up to you to make the most important decisions that, together with the 3 P's, will shape your bird:
 
@@ -70,7 +70,7 @@ When you have decided on these aspects, you will see that Blackbird will take ca
 
 Let's take this theoretical workflow and put it into practise. In the image below you see an example of the pull, process and push steps with their respective actions in Contentful. The **Get entry as HTML file** is used to retrieve an HTML file representing the entry. In this case, DeepL is used in order to process the file (translating it into another language). Then finally, the **Update entry from HTML file** action is used to take the translated HTML file from DeepL and push it back to Contentful. Of course, DeepL can be swapped out for any other single-action processing application and this workflow would look similarly with other CMSs.
 
-![Core with NMT](../../../assets/guides/cms/1729083328505.png)
+![Core with NMT](~/assets/guides/cms/1729083328505.png)
 
 ### 2.2 Human-in-the-orchestration
 
@@ -78,7 +78,7 @@ It's more than likely that mere machine processing does not satisfy your localiz
 
 > **💡 Note**: Checkout our [checkpoints concept guide](../../concepts/checkpoints) to learn more about checkpoints!
 
-![Core with TMS](../../../assets/guides/cms/1729083153924.png)
+![Core with TMS](~/assets/guides/cms/1729083153924.png)
 
 ## 3. Continuous localization
 
@@ -86,7 +86,7 @@ You have learned how the core translation workflow is typically constructed in a
 
 For our Contentful core translation workflow, all we actually need to do is create an event that is triggered when new content is created (or published in our case). Then we point the **Get entry as HTML file** to the entry ID we receive from the event.
 
-![Continuous localization](../../../assets/guides/cms/continuous.gif)
+![Continuous localization](~/assets/guides/cms/continuous.gif)
 
 That's it! Continuous localization checked off. ✔️
 
@@ -94,7 +94,7 @@ The critical reader, Contentful veteran or both, will point out a small flaw in 
 
 We recommend looking into the supporting features that CMSs have like **tags** or **custom fields** as mentioned earlier. A popular way to deal with this in Contentful is to use the tags system. You can add filters to the entry events in Blackbird so that only entries with a certain tag will trigger the bird. A good candidate could be *Ready for localization*. Be sure to delete the tag at the end of your workflow!
 
-![Core with tags](../../../assets/guides/cms/1729086551991.png)
+![Core with tags](~/assets/guides/cms/1729086551991.png)
 
 ## 4. Scheduled and historical localization
 
@@ -102,7 +102,7 @@ It's possible that continuous localization doesn't quite tickle your fancy. Perh
 
 Every CMS has an action in the shape of *Search entities*, which you can use to search and select the exact content you want to process. It ususally comes with different filters including a *Updated from* and *Updated to* filter that you can use to select the time range in which the content is allowed to be updated.
 
-![Scheduled memoQ](../../../assets/guides/cms/1729090495297.png)
+![Scheduled memoQ](~/assets/guides/cms/1729090495297.png)
 
 ## 5. Processing multiple languages
 
@@ -110,13 +110,13 @@ So far every bird we've seen only translated the content into one language. Howe
 
 In the easiest scenario the languages you want to translate to are pre-defined as per some agreement. Usually you can then "hardcode" these languages into the actions that require them. It's also likely that you want to be clever and get the languages as they are defined in the CMS. Most CMS apps havea **Get locales** or **Get languages* action that will return the default language and the other languages that are configured. This is perfect! Because now you can send those languages directly into your processing application.
 
-![TMS languages](../../../assets/guides/cms/1729176014667.png)
+![TMS languages](~/assets/guides/cms/1729176014667.png)
 
 There is a very important thing to point out when sending languages from one system to the other: they may not be using the same languages codes. That's why in the bird section above we are using the **Convert operator** to convert from Contentful language codes into memoQ language codes. You can read more about conversion and libraries in [this guide](../../concepts/libraries).
 
 A TMS can usually take all the languages you want to convert to in a single input field, since it would create a project for your content. However, NMT and other single-step processing apps tend to only take one language at a time. In this case you will have to loop over all the languages and process them for each file (see gif below). You can find more information about loops [here](../loops).
 
-![Continuous localization](../../../assets/guides/cms/multilocales.gif)
+![Continuous localization](~/assets/guides/cms/multilocales.gif)
 
 ## 6. Contentful gotchas
 
@@ -147,7 +147,7 @@ In the action you are able to select exactly which type of linked entry you want
 
 Finally, finding embeded entries recursively but indefinitely can be quite dangerous. You may want to explain to Blackbird where and with which field types to stop. You can specify a list of Field IDs which will always be ignored and not added to the produced HTML file.
 
-![Contentful surgical](../../../assets/guides/cms/1729093156381.png)
+![Contentful surgical](~/assets/guides/cms/1729093156381.png)
 
 ### 6.2 Contentful workflows
 

--- a/src/content/docs/guides/entity-linking.md
+++ b/src/content/docs/guides/entity-linking.md
@@ -33,13 +33,13 @@ Then:
 
 Without going over the details, the first part of the workflow looks like this:
 
-![Initial](../../../assets/guides/linking/initial.png)
+![Initial](~/assets/guides/linking/initial.png)
 
 We are using a loop over all the attachments in the issue, then download the attachment and create a Phrase job out of these, together with the language that was selected from a dropdown in Jira.
 
 Then se second part of the workflow will look like this:
 
-![Missing key](../../../assets/guides/linking/missing-key.png)
+![Missing key](~/assets/guides/linking/missing-key.png)
 
 We download the translated file and then we want to add it to our Jira ticket. However, we are now confronted with the exact same problem we mentioned earlier: **given this completed job, what issue did it correspond to?**
 
@@ -51,11 +51,11 @@ In order to answer this question, we need to add one more step to our first work
 
 Click on the `+` icon and select _Operator_. Then on the menu on the right, select _Entity connection_.
 
-![Connection](../../../assets/guides/linking/connection.png)
+![Connection](~/assets/guides/linking/connection.png)
 
 Then for type select _Link entities_. We now have to define the names and the IDs of our two entities. We recommend using recognizable names. In our case we use `Jira_issue` and we select the _Issue key_ (which is the ID for the issue which we'll want in our second bird), and we link it to `Phrase_job` and add the _UID_ of the Phrase job we just created.
 
-![Setup](../../../assets/guides/linking/setup.png)
+![Setup](~/assets/guides/linking/setup.png)
 
 Done! We can now fly this bird and verify that it does so succesfully. When we have added the _Link entities_ operator to our bird we can now make use of this link in our other bird.
 
@@ -65,7 +65,7 @@ Done! We can now fly this bird and verify that it does so succesfully. When we h
 
 Let's return to the bird responsible for putting the translations back into Jira. Between the Phrase and Jira actions we can now add the _Entity connection_ operator again. This time, instead of choosing _Link entities_ as its type, we will choose _Get linked entity_.
 
-![Get entity](../../../assets/guides/linking/get-entity.png)
+![Get entity](~/assets/guides/linking/get-entity.png)
 
 When we click on _name_, we will see a dropdown with all the different entity types that Blackbird stored for you. We know that we havea Phrase job and we want a Jira issue, therefore, we select `Phrase_job` and fill in the Job ID we received through the event. Then for connected entity, we select `Jira_issue`.
 
@@ -73,7 +73,7 @@ Hooray! We have now retrieved the linked entity!
 
 We can now use this ID (which in our case represents the Jira issue key) in our final action to complete the bird.
 
-![Complete](../../../assets/guides/linking/complete.png)
+![Complete](~/assets/guides/linking/complete.png)
 
 Et Voila, when the Phrase job is completed, we now see our attachments returned in the correct Jira ticket! 🎉
 

--- a/src/content/docs/guides/error-handling.md
+++ b/src/content/docs/guides/error-handling.md
@@ -19,7 +19,7 @@ To set up a retry policy in Blackbird:
 2. Define the maximum number of retries in the '_Number of retries_' field.
 3. Specify the retry interval in the '_Frequency (Seconds)_' field.
 
-![Retry policy](../../../assets/guides/errors/retry.png)
+![Retry policy](~/assets/guides/errors/retry.png)
 
 The bird will now attempt to re-execute the action the designated number of times at the specified interval if it encounters an error.
 
@@ -44,7 +44,7 @@ To enable this:
 1. Find the desired action in your workflow, then go to the '_Error Handling_' tab.
 2. Toggle '_Enable Skip Action_' on.
 
-![Skip](../../../assets/guides/errors/skip.png)
+![Skip](~/assets/guides/errors/skip.png)
 
 Now, if this particular action errors, it will be skipped, allowing the workflow to proceed.
 

--- a/src/content/docs/guides/hubspot-plunet.md
+++ b/src/content/docs/guides/hubspot-plunet.md
@@ -38,7 +38,7 @@ Let's start with Plunet, but let's be brief:
 - There can be multiple orders, each representing business negotiated with a customer.
 - A Plunet order is linked to an 'internal resource' as project manager, a customer and a contact person of that customer.
 
-![Plunet diagram](../../../assets/guides/hubspot-plunet/plunet-diagram.png)
+![Plunet diagram](~/assets/guides/hubspot-plunet/plunet-diagram.png)
 
 In Hubspot, things look similar but with a significant difference:
 
@@ -47,13 +47,13 @@ In Hubspot, things look similar but with a significant difference:
 - There are multiple deals. A deal has a 'deal owner' who is a Hubspot user
 - Between these three entities, many-to-many relationships exist. And Hubspot uses 'associations' to keep track of these relationships.
 
-![Hubspot diagram](../../../assets/guides/hubspot-plunet/hubspot-diagram.png)
+![Hubspot diagram](~/assets/guides/hubspot-plunet/hubspot-diagram.png)
 
 These structures are similar enough to create a mapping between the two. However, in some cases these similarities don't exist. In those cases it is prudent to investigate how people have mapped these relationships in their organization.
 
 Let's draw the semantic relationship map:
 
-![Hubspot Plunet](../../../assets/guides/hubspot-plunet/hubspot-plunet.png)
+![Hubspot Plunet](~/assets/guides/hubspot-plunet/hubspot-plunet.png)
 
 ## 3. Implementating the relationships
 
@@ -63,11 +63,11 @@ Somewhere, references to the other equivalent entity need to be stored. Luckily,
 
 For Plunet, we create a _text module_ and apply it to Customers, internal resources, and orders. The name of the text module will be _Hubspot ID_ so that we can save the Hubspot IDs of equivalent entities. For more information on text modules, see the [Plunet documentation](https://kb.plunet.com/display/KB/Text+modules).
 
-![Plunet text module](../../../assets/guides/hubspot-plunet/plunet-text-module.png)
+![Plunet text module](~/assets/guides/hubspot-plunet/plunet-text-module.png)
 
 In Hubspot, every entity can also have _Custom properties_ (Settings -> Data Management -> Properties). We can create a new property on each of our relevant entities. For more information on custom properties, see the [Hubspot documentation](https://knowledge.hubspot.com/properties/create-and-edit-properties)
 
-![Plunet properties](../../../assets/guides/hubspot-plunet/hubspot-properties.png)
+![Plunet properties](~/assets/guides/hubspot-plunet/hubspot-properties.png)
 
 We have not created the infrastructure required to semantically link the entities in our two separate systems and we're ready to move on to the next step!
 
@@ -97,7 +97,7 @@ So it seems that our bird is going to be pretty straightforward! We perform abou
 
 Finally, we're ready to build the bird! If you have planned your actions correctly then the actions in your bird should basically correspond with the manual steps you would have to perform.
 
-![Simple bird](../../../assets/guides/hubspot-plunet/bird-simple.png)
+![Simple bird](~/assets/guides/hubspot-plunet/bird-simple.png)
 
 As you can see, the numbered actions correspond to the steps we planned above!
 
@@ -115,7 +115,7 @@ The best way to circumvent this new problem we created for ourselves, is to simp
 
 With those details added, our complete bird looks like this:
 
-![Complete bird](../../../assets/guides/hubspot-plunet/complete-bird.png)
+![Complete bird](~/assets/guides/hubspot-plunet/complete-bird.png)
 
 Congratulations! You have taken all the solution architect's steps in order to create a production ready bird!
 
@@ -146,7 +146,7 @@ Manual steps (after a company is created in Hubspot):
 
 Bird:
 
-![Complete bird](../../../assets/guides/hubspot-plunet/company-sync.png)
+![Complete bird](~/assets/guides/hubspot-plunet/company-sync.png)
 
 > The biggest difference between customers and contacts in Plunet is that contacts don't have text modules. Luckily they instead have an "external ID" property that we can use.
 

--- a/src/content/docs/guides/loops.md
+++ b/src/content/docs/guides/loops.md
@@ -14,33 +14,33 @@ In Blackbird, actions in a workflow can sometimes produce outputs that come in g
 
 Take this "Get message" action from Slack. As a message can contain multiple attachments, Blackbird returns a "group" of attachments (even if in a particular message there is just one attachment). Checking the Flights tab, we can see the square brackets "[]" around the "list" of attachments. This is key to identifying arrays.
 
-![Slack output](../../../assets/guides/loops/Loop_SS1.png)
+![Slack output](~/assets/guides/loops/Loop_SS1.png)
 
 ## What does the Loop do?
 Think of the Loop like a helpful assistant that takes each item in the group, one by one, and carries it through the next action. It's like going through a checklist item by item, making sure everything gets done.
 
 Let's say, going back to our example, that we want to translate those attached files through DeepL. So we look up DeepL's "Translate Document" action. We can see that this action is expecting a File as one of its inputs. However, when we try the _Magic Wand_ to list the outputs of our previous actions, we don't see our attached files listed. This is because the new action is expecting a single file, not many, not a group. Time to add a Loop.
 
-![DeepL empty input](../../../assets/guides/loops/Loop_SS2.png)
+![DeepL empty input](~/assets/guides/loops/Loop_SS2.png)
 
 ## How to add a Loop?
 Same way as a new action would be added, clicking the plus sign. But instead of choosing Actions, Operators or Decisions, we select `Loop`. After this, the "group of items" we want to iterate through needs to be selected.
 
-![Plus Sign Options](../../../assets/guides/loops/Loop_SS3.png)
+![Plus Sign Options](~/assets/guides/loops/Loop_SS3.png)
 
-![Choosing our array](../../../assets/guides/loops/Loop_SS4.png)
+![Choosing our array](~/assets/guides/loops/Loop_SS4.png)
 
 ##  Which actions to place inside?
 Actions that need to happen repeatedly, or per each item in my group/array, are placed inside the Loop using the plus sign again and selecting said action(s). Check the flow lines going back to the Loop's start point, as if repeating over itself (until we run out of items in the group, that is).
  
-![New DeepL input and highlighted flow line](../../../assets/guides/loops/Loop_SS5.png)
+![New DeepL input and highlighted flow line](~/assets/guides/loops/Loop_SS5.png)
 
 ## Keeping actions outside the Loop
 But what about actions that don't need to happen for each individual item? Those can stay outside the Loop. These are tasks that only need to be done once, regardless of the number of items in the group.
 
 Let's say that we want to place our attached files within a memoQ project and use them as source files. If we wanted to create one project per attached file, all we would have to do would be to place a "Create Project" action within the Loop going through each file. Nevertheless, we actually want one project to contain all our files. Therefore, the "Create project" action needs to happen outside my Loop, and only include "Import Document" within the Loop taking as input each single file and iterating through them until all are imported; then the flow will continue with single actions again, maybe getting information from my newly created project _overall and once_.
 
-![memoq steps](../../../assets/guides/loops/Loop_SS6.png)
+![memoq steps](~/assets/guides/loops/Loop_SS6.png)
 
 > For ease of use, we suggest renaming your Loop to something that makes it absolutely clear to you what items you are running through. To do this, use the pencil icon next to your action title in the right pane, while said action is select.
 

--- a/src/content/docs/guides/manual-triggers.md
+++ b/src/content/docs/guides/manual-triggers.md
@@ -9,7 +9,7 @@ sidebar:
 
 Manual triggers (also referred to as Manual push) offer a powerful solution for workflows that require flexibility and human intervention. Unlike automated processes, manual triggers allow users to initiate a workflow exactly when needed by clicking the Fly button. This feature is particularly useful for any user that needs to start tasks based on specific conditions or human judgment. Whether it's for testing new Birds, debugging workflows, or handling one-off projects, manual triggers give you control over the timing and initiation of processes, ensuring tasks start when you're ready.
 
-![Fly button](../../../assets/docs/triggers/Fly.gif)
+![Fly button](~/assets/docs/triggers/Fly.gif)
 
 A key advantage of manual triggers is the flexibility they provide. Instead of being tied to rigid, scheduled workflows or waiting for an event to react to, you can activate processes on demand, making them ideal for situations where unpredictable conditions require human discretion. This makes manual triggers the perfect choice during the development phase of a workflow. As you build and refine your Birds, manual initiation lets you test various elements without waiting for a scheduled or event trigger, providing real-time feedback and helping ensure a smooth process before full automation is applied.
 
@@ -17,7 +17,7 @@ Manual triggers also shine in the localization and content processing space. As 
 
 ### Example
 
-![Sitecore](../../../assets/docs/triggers/Sitecore_DownloadItems.png)
+![Sitecore](~/assets/docs/triggers/Sitecore_DownloadItems.png)
 
 The image above shows a Bird that moves a large group of Sitecore pages meeting specific criteria into a TMS (Trados in this case). Once the user clicks the Fly button — the manual trigger — the workflow begins. The Bird searches for all pages in Sitecore created after January 1st, 2024, that are published. The optional input filters have been used to customize the search criteria, making it easy to adjust them as needed. These filters help identify which pages to download. The subsequent steps in the workflow create a project in Trados, retrieve the Sitecore pages as HTML files, download them, and upload them into the newly created Trados project as source content for translation. This workflow can be executed as many times as necessary by clicking the Fly button, although one execution should be enough to pull all the required content for translation and push it into the TMS of choice.
 

--- a/src/content/docs/guides/sso.md
+++ b/src/content/docs/guides/sso.md
@@ -16,7 +16,7 @@ At Blackbird, we offer flexible sign-in options to suit your needs. You can eith
 
 On the sign-in screen, select the Google or Microsoft button after entering your email address.
 
-![Initial](../../../assets/guides/sso/buttons.png)
+![Initial](~/assets/guides/sso/buttons.png)
 
 This action will open the selected service and prompt you to sign in, if you haven't done so already.
 

--- a/src/content/docs/guides/toolbox.md
+++ b/src/content/docs/guides/toolbox.md
@@ -18,22 +18,22 @@ The [Utilities](https://docs.blackbird.io/apps/utilities/) app provides a wide r
 - Files: 
     - You can extract the name of a file and even change it - you may want to append the language name you are translating the file into to the name of the file. 
     - You can also get the extension of a file, which would be very useful in case you need to route files of different types into different paths. 
-    ![Getting File Extension](../../../assets/guides/toolbox/Toolbox_1.png)
+    ![Getting File Extension](~/assets/guides/toolbox/Toolbox_1.png)
     - You can count the number of words or characters in a file. Maybe you need to keep track of how many characters are sent to your MT engine because you are charged based on this, then it becomes a valuable piece of data to extract and record. 
 - Text:
     - It is also possible to count words and characters from text formats. So, if you pick up a message from Slack or Teams, or you want to know how long a file name is, you can use the actions in Utilities to count any of these.
-    ![Char count of text](../../../assets/guides/toolbox/Toolbox_2.png)
+    ![Char count of text](~/assets/guides/toolbox/Toolbox_2.png)
     - Regular expressions can be used to extract or replace content from text. While extracting content, you can specify as optional parameter the group number you want to extract specifically. Or you can use grouping with the replace action to regroup parts of your text. With these options you can extract email addresses from a message or a list of language codes from an email body. 
-    ![Extract with Regex](../../../assets/guides/toolbox/Toolbox_3.png)
+    ![Extract with Regex](~/assets/guides/toolbox/Toolbox_3.png)
 - Range of numbers:
     - Providing a start and end point, a range of numbers can be generated. This is particularly useful when paired with a Loop because you need to repeat an action an X number of times. A good use case is iterating through the rows of a table (think of Microsoft Excel) and getting information from column A, processing it and finally pasting the result to column B. In this scenario, you can use the numbers in the range to indicate the row number.
-    ![Range and Excel](../../../assets/guides/toolbox/Toolbox_4.png)
+    ![Range and Excel](~/assets/guides/toolbox/Toolbox_4.png)
 - Arrays:
     - There are also a couple of useful option to work with arrays or groups of items. Using the "Array Contains" action you can check whether one value is included in the array or not, and make decisions based on that. For instance, one of your clients does not exist in your list of contacts, therefore you can add them without creating duplicates. 
     - Speaking of duplicates, there is also an action to return a list of unique values given an array as input. 
 - Scraping:
     - Raw and unformatted web page content can be extracted from a URL. You can also provide an XPATH to specify the exact content to be scrapped. This is particularly useful if you need to take content from a webpage but don't have access to the CMS or source code.
-    ![Scrapping + summarize](../../../assets/guides/toolbox/Toolbox_5.png)
+    ![Scrapping + summarize](~/assets/guides/toolbox/Toolbox_5.png)
 
 - XML files:
     - If you are working with XML files, you may need to get the value from a specific property, or change it, or even update the version property. These are all possible. 
@@ -45,7 +45,7 @@ The [Utilities](https://docs.blackbird.io/apps/utilities/) app provides a wide r
 
 This app contains a collection of pre-engineered prompts that can be used in conjunction with different AI apps. These prompts have proved to be successful when working with language actions. The list comprises prompts for getting translation issues, summarizing text, getting translation reports, performing post editing, and more. 
 
-![List of prompts](../../../assets/guides/toolbox/Toolbox_6.png)
+![List of prompts](~/assets/guides/toolbox/Toolbox_6.png)
 
 ## HTTP app
 
@@ -55,11 +55,11 @@ This application allows you to perform basic HTTP requests (GET/POST/PUT/PATCH/D
 
 When adding an action via plus sign, you can also choose to add an Operator instead. The string operator is very handy and popular as it allows very interesting options.
 
-![Operators](../../../assets/guides/toolbox/Toolbox_7.png)
+![Operators](~/assets/guides/toolbox/Toolbox_7.png)
 
 - String Compose: This option allows the user to compose a message, whether by typing or using outputs from previous actions or both multiple times. This super powerful tool allows you to create a message stating, for example, that the article + _the name of the article_ + has been published to + _the URL value_ + in + _language it has been translated to_.
 
-![Compose message](../../../assets/guides/toolbox/Toolbox_8.png)
+![Compose message](~/assets/guides/toolbox/Toolbox_8.png)
 
 - String Split: Given a string of text, maybe a list of items in text format. You can specify the separator and get in return an actual list that you can loop through and treat each of these items separately. 
 

--- a/src/content/docs/guides/xliff.md
+++ b/src/content/docs/guides/xliff.md
@@ -9,7 +9,7 @@ sidebar:
 
 XLIFF (XML Localization Interchange File Format) is the beacon of standardization in the language and localization industry, allowing for the seamless exchange of translation data. It organizes content into translation units, each comprising a source segment and its corresponding target translation.
 
-![Image of XLIFF](../../../assets/guides/xliff/ImageOfXliff.png)
+![Image of XLIFF](~/assets/guides/xliff/ImageOfXliff.png)
 
 While most Translation Management Systems (TMS) and Computer-Assisted Translation (CAT) tools effortlessly handle XLIFF files, some other tools may not be as file-friendly. However, in the realm of Blackbird, where interoperability reigns supreme, we've unfurled new wings—er, actions—to make XLIFFs soar even in non-file-friendly apps.
 
@@ -64,9 +64,9 @@ Our [ModernMT](https://docs.blackbird.io/apps/modernmt/) app has also been adapt
 
 Our newest Blackbird actions allow for a bird's-eye view of your XLIFF's quality. By calculating the quality score of each segment within the XLIFF and returning an aggregated number that gives us an idea of the overall quality in the file. This was previously reserved for single segments only. Additionally, all translation units get appeneded with their individual score which is added to the extradata attribute in the XLIFF file.
 
-![Average Scores as output](../../../assets/guides/xliff/AverageScore.png)
+![Average Scores as output](~/assets/guides/xliff/AverageScore.png)
 
-![Image of extradata and scores](../../../assets/guides/xliff/Imageofextradataandscores.png)
+![Image of extradata and scores](~/assets/guides/xliff/Imageofextradataandscores.png)
 
 Optionally, Threshold, New Target State and Condition input parameters can be set to the Blackbird action to change the target state value of segments meeting the desired criteria. This means that you can signal properly translated segments and block them when importing the XLIFF file into a TMS for human revision, saving time and money and focusing efforts in those segments that actually need editing.
 
@@ -74,12 +74,12 @@ Example
 
 Setting the optional input values as shown in the image below will result in all segments with a score above 0.9 to have their target state values updated to “final”. When importing these XLIFF files into TMS tools, a setting can be usually added to lock segments with a specific target value ("final" in this case), so that translators can focus on and edit only the segments of lower quality.
 
-![Optional Input](../../../assets/guides/xliff/optionalinput.png)
+![Optional Input](~/assets/guides/xliff/optionalinput.png)
 
-![Updated Target State](../../../assets/guides/xliff/UpdatedTargetState.png)
+![Updated Target State](~/assets/guides/xliff/UpdatedTargetState.png)
 
 ## Behold, a majestic bird in action!
 
 While the new actions on its own add great value and enable new possibilities, when chained, they become even more powerful. Below is an example bird that takes a .docx file as input, the file is then converted into XLIFF for interoperability purposes, OpenAI is then used to translate the file into the target language. After this, TAUS is used to determine the quality of said translations and a decision operator is used to define the next steps for the file: if the average quality score is above the defined 0.95 threshold, the XLIFF is then converted into a translated .docx and delivered as final. Otherwise, if the average score is below 0.95, the file is imported into a TMS for further human editing. This ensures that only files that actually need a human in the loop are uploaded into the TMS, while quality translations are immediately delivered back.
 
-![screenshot of bird](../../../assets/guides/xliff/XliffSampleBird.png)
+![screenshot of bird](~/assets/guides/xliff/XliffSampleBird.png)

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ template: splash
 hero:
   tagline: The backbone for the language technology industry. Enterprise-scale automation and orchestration with a simple no-code/low-code platform.
   image:
-    file: ../../assets/bird.svg
+    file: ~/assets/bird.svg
   actions:
     - text: Get started
       link: /learning-to-fly/introduction/

--- a/src/content/docs/learning-to-fly/first-connection.md
+++ b/src/content/docs/learning-to-fly/first-connection.md
@@ -14,4 +14,4 @@ Before you begin you need to make sure that you have an app. You can navigate to
 
 When you have one or multiple apps added in your view, you can click on the app to start connecting. On the connections screen click _Add connection_. Follow the instructions or read the app specific documentation.
 
-![connection](../../../assets/docs/connection.png)
+![connection](~/assets/docs/connection.png)

--- a/src/content/docs/sdk/actions.md
+++ b/src/content/docs/sdk/actions.md
@@ -55,7 +55,7 @@ public class GetBerryRequest
 
 This class is transformed to:
 
-![connection](../../../assets/docs/berry.png)
+![connection](~/assets/docs/berry.png)
 
 Just as with input arguments, the `[Display]` atribute also works on the return types of your actions in order to give them user-friendly names.
 

--- a/src/content/docs/sdk/connections.md
+++ b/src/content/docs/sdk/connections.md
@@ -63,7 +63,7 @@ Your connection property can also be a dropdown list of finite values. Use the `
 
 Which will render the dropdown:
 
-![dropdown](../../../assets/docs/dropdown.png)
+![dropdown](~/assets/docs/dropdown.png)
 
 ## Transforming connection properties into credentials
 
@@ -238,7 +238,7 @@ public class ConnectionValidator : IConnectionValidator
 
 After having all of this setup, Blackbird can now display the connection form to the user.
 
-![connection](../../../assets/docs/connection_modal.png)
+![connection](~/assets/docs/connection_modal.png)
 
 ## Accessing credentials in actions and events
 

--- a/src/content/docs/sdk/conventions.md
+++ b/src/content/docs/sdk/conventions.md
@@ -89,9 +89,9 @@ Secondly, take into account that connection fields can also have display names, 
 
 Connection field names should be short, descriptive and clear. From the field name the user should be able to figure out what exact data is required from them.
 
-![Connection definition](../../../assets/docs/conventions/connection_fields.png)
+![Connection definition](~/assets/docs/conventions/connection_fields.png)
 
-![Connection details](../../../assets/docs/conventions/connection_details.png)
+![Connection details](~/assets/docs/conventions/connection_details.png)
 
 ## 5. Data sources
 
@@ -230,7 +230,7 @@ In many apps that Blackbird typically connects with, it's very common that files
 Because users often think of files as batches, we want to enhance their experience and not force users to have to resort to loops to do very basic operations. If the envisioned bird is to move files from a folder to a project, then no loop should have to be required.
 
 On a very high level, most apps should be able to follow this pattern:
-![File actions](../../../assets/docs/conventions/file_actions.png)
+![File actions](~/assets/docs/conventions/file_actions.png)
 
 In order to do this we need to adhere to the following principles:
 

--- a/src/content/docs/sdk/datasources.md
+++ b/src/content/docs/sdk/datasources.md
@@ -47,7 +47,7 @@ The `DataSourceContext.SearchString` provides the typed in search string by the 
 
 You should return a `IEnumerable<DataSourceItem>` where the `value` argument of a `DataSourceItem` represents the value that will be "filled in" e.g. the ID of a certain status or entity. The second argument is the displayed name.
 
-![connection](../../../assets/docs/dynamic_input.png)
+![connection](~/assets/docs/dynamic_input.png)
 
 ### Advanced context
 

--- a/src/content/docs/sdk/deploying.md
+++ b/src/content/docs/sdk/deploying.md
@@ -14,7 +14,7 @@ Before deploying an app, make sure that it at least contains a class that implem
 
 1. Right-click on your project in the solution explorer and click _Publish_
 
-![connection](../../../assets/docs/publishing.png)
+![connection](~/assets/docs/publishing.png)
 
 2. If you have not created a publish profile yet, create a publish profile that publishes to a local folder.
 3. Click _Publish_ and then _Open folder_
@@ -22,7 +22,7 @@ Before deploying an app, make sure that it at least contains a class that implem
 
 > **Note: If you are working on a Mac, make sure to delete the hidden _\_MACOSX_ folder in the zip archive before uploading it to Blackbird.**
 
-![zipping](../../../assets/docs/zipping.png)
+![zipping](~/assets/docs/zipping.png)
 
 ## Uploading
 
@@ -32,4 +32,4 @@ If you want to update an existing app. On the app you want to update click _New 
 
 > Note: When updating an app, make sure that the new version of the app (defined in the `.csproj` file) is higher than the existing version.
 
-![zipping](../../../assets/docs/upload.png)
+![zipping](~/assets/docs/upload.png)

--- a/src/content/docs/sdk/errors.md
+++ b/src/content/docs/sdk/errors.md
@@ -12,7 +12,7 @@ There are 5 different types of errors that can be displayed on the flights page.
 
 ## 1. Configuration error
 
-![Configuration exception](../../../assets/docs/conventions/configuration_error.png)
+![Configuration exception](~/assets/docs/conventions/configuration_error.png)
 
 The purpose of this error is to notify the user that **they made a mistake** and **only they can resolve**. This typically happens with misconfigured variables, values or environments. Hence this error type is called a *configuration error*. Examples of configuration errors are:
 
@@ -48,7 +48,7 @@ try
 
 ## 2. App not responding
 
-![app not responding](../../../assets/docs/conventions/not_responding_error.png)
+![app not responding](~/assets/docs/conventions/not_responding_error.png)
 
 The purpose of this error is to notify the user that **the connected app has issues that neither you** (the app developer), **nor the user can do anything about**. This is typically the case when the app throws an unexpected issue (500), or when the API throws an error that is intended for the user, rather than the app developer. Examples are:
 
@@ -62,7 +62,7 @@ The app not responding error can be thrown with the `PluginApplicationException`
 
 ## 3. Unexpected app issue
 
-![unexpected_error](../../../assets/docs/conventions/unexpected_error.png)
+![unexpected_error](~/assets/docs/conventions/unexpected_error.png)
 
 All other errors that are thrown by your app will appear as *unexpected errors*. The goal is to **minimize the amount of unexpected errors**. If an unexpected error is seen, it's the responsibility of the app developer to either handle the error in code, or throw any of the other 2 error types.
 

--- a/src/content/docs/sdk/events.md
+++ b/src/content/docs/sdk/events.md
@@ -198,7 +198,7 @@ public Task<WebhookResponse<CallbackPayload>> OnCallbackReceived(WebhookRequest 
 
 This translates to:
 
-![callback](../../../assets/docs/callback.png)
+![callback](~/assets/docs/callback.png)
 
 > Tip: one can use the callback functionality to create "callable" birds as if Blackbird had its own API.
 

--- a/src/content/docs/sdk/setup.md
+++ b/src/content/docs/sdk/setup.md
@@ -36,7 +36,7 @@ To use the NuGet Package Manager to install the `Blackbird.Applications.Sdk.Comm
 3. From the _Browse_ tab, search for _Blackbird.Applications.Sdk.Common_, select `Blackbird.Applications.Sdk.Common` in the list, and then select _Install_.
 4. When you are prompted to verify the installation, select _OK_.
 
-![nuget](../../../assets/docs/nuget.png)
+![nuget](~/assets/docs/nuget.png)
 
 ## From a template
 
@@ -58,4 +58,4 @@ When deploying your modifications, you do so in a custom app. Please see the [de
 
 Blackbird uses properties defined in the `.csproj` file to populate metadata fields. For most custom apps, only the Version and AssemblyName are relevant (the other properties are defined in the UI). When uploading a newer version of an existing app, make sure the version number is higher.
 
-![nuget](../../../assets/docs/csproj.png)
+![nuget](~/assets/docs/csproj.png)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "astro/tsconfigs/strictest"
+  "extends": "astro/tsconfigs/strictest",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
## Problem

Current approach is using links with hardcoded nesting like this:

```md
![Shopify to Phrase](../../../assets/guides/checkpoints/ShopifyToPhrase.png)

file: ../../assets/bird.svg
```

The best practice is to use links relative to `src` folder like this:

```md
![Shopify to Phrase](~/assets/guides/checkpoints/ShopifyToPhrase.png)

file: ~/assets/bird.svg
```

This allows changing directory structure (which in practice happens rarely) and enables creation of localized pages. 


## Solution

The main change is in `tsconfig.json`:
https://github.com/terales/blackbird-docs/blob/ee51ff24000d6f47b21ca126c7dc7bbcdd8cf06a/tsconfig.json#L3-L8

```json
"compilerOptions": {
    "baseUrl": ".",
    "paths": {
        "~/*": ["src/*"]
    }
}
```

This is the same approach as starlight repository is using themselves:
https://github.com/withastro/starlight/blob/main/docs/tsconfig.json

Other changes are trivial change or the asset paths in the docs. No files `apps/` are affected.

## Testing

I've checked pages locally and images were visible.

Also, I've deployed an internationalized version of docs using the same changes and images are visible there too: https://terales.github.io/blackbird-docs/